### PR TITLE
Switch to latest duniter release + ynh_port_find helper

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -56,3 +56,20 @@ fi
 # Remove Duniter package
 sudo dpkg -r duniter
 }
+
+# Find a free port and return it
+#
+# example: port=$(ynh_find_port 8080)
+#
+# usage: ynh_find_port begin_port
+# | arg: begin_port - port to start to search
+ynh_find_port () {
+	port=$1
+	test -n "$port" || ynh_die "The argument of ynh_find_port must be a valid port."
+	while netcat -z 127.0.0.1 $port       # Check if the port is free
+	do
+		port=$((port+1))	# Else, pass to next port
+	done
+	echo $port
+}
+

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -2,7 +2,7 @@
 
 INSTALL_DUNITER_DEBIAN_PACKAGE () {
 # Retrieve url of last version and version number
-url=$(curl -s https://api.github.com/repos/duniter/duniter/releases | grep "browser_" | grep $arch | grep "linux" | grep "server" | sort -r | head -1 | cut -d\" -f4)
+url=$(curl -s https://api.github.com/repos/duniter/duniter/releases/latest | grep "browser_" | grep $arch | grep "linux" | grep "server" | sort -r | head -1 | cut -d\" -f4)
 version=$(echo $url | cut -d/ -f8)
 
 # Retrieve debian package and install it

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -56,20 +56,3 @@ fi
 # Remove Duniter package
 sudo dpkg -r duniter
 }
-
-# Find a free port and return it
-#
-# example: port=$(ynh_find_port 8080)
-#
-# usage: ynh_find_port begin_port
-# | arg: begin_port - port to start to search
-ynh_find_port () {
-	port=$1
-	test -n "$port" || ynh_die "The argument of ynh_find_port must be a valid port."
-	while netcat -z 127.0.0.1 $port       # Check if the port is free
-	do
-		port=$((port+1))	# Else, pass to next port
-	done
-	echo $port
-}
-

--- a/scripts/install
+++ b/scripts/install
@@ -22,7 +22,10 @@ sudo yunohost app checkurl "${domain}${path}" -a "$app" \
     || ynh_die "Path not available: ${domain}${path}"
 
 # Check port availability
-port=$(ynh_find_port $port)
+sudo yunohost app checkport $port
+if [[ ! $? -eq 0 ]]; then
+  ynh_die "Port not available: ${port}"
+fi
 
 # Check node availability
 if curl --output /dev/null --silent --head --fail "$sync_node:$sync_port/node/summary"; then

--- a/scripts/install
+++ b/scripts/install
@@ -22,10 +22,7 @@ sudo yunohost app checkurl "${domain}${path}" -a "$app" \
     || ynh_die "Path not available: ${domain}${path}"
 
 # Check port availability
-sudo yunohost app checkport $port
-if [[ ! $? -eq 0 ]]; then
-  ynh_die "Port not available: ${port}"
-fi
+port=$(ynh_find_port $port)
 
 # Check node availability
 if curl --output /dev/null --silent --head --fail "$sync_node:$sync_port/node/summary"; then


### PR DESCRIPTION
Unable to install duniter on 2.6.2 yunohost test server without this helper 
and the v1.2.3 doesn't work at this time.