### PR TITLE
Add Nginx conf for modules

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -37,5 +37,10 @@ location / {
 		proxy_pass http://localhost:9220$uri;
 		access_by_lua_file /usr/share/ssowat/access.lua;
 	}
+	
+	location ~ /modules {
+		proxy_pass http://localhost:9220$uri;
+		access_by_lua_file /usr/share/ssowat/access.lua;
+	}
 
 }


### PR DESCRIPTION
This will redirect any call to `/modules` to the web admin. Protected by YunoHost access file.