### PR TITLE
Fix: Define home when applying Duniter config, move duniter conf to common.sh, define bma endpoint with /bma path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Crypto-currency software to operate Ğ1 libre currency
 
-**Shipped version:** 1.8.2~ynh1
+**Shipped version:** 1.8.2~ynh2
 
 
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Crypto-currency software to operate Ğ1 libre currency
 ## Disclaimers / important information
 
 ## Configurations
-- In order to compute blocks you will have to set your member credentials with `sudo su - duniter -c "duniter wizard key"` or from the webadmin.
+- In order to compute blocks you will have to set your member credentials with `sudo su - duniter -c "duniter --home \$HOME wizard key"` or from the webadmin.
 - BMA, the client API is accessible from `https://duniter.domain.tld/bma/` if enabled . The last `/` is necessary. It can be used in Cesium and Silkaj.
 - The web administration interface is accessible via `https://duniter.domain.tld/` and is only accessible to the administrator specified at the installation.
 - **Warning**: In case the Webui tells you your network configuration is wrong and proposes to correct it, do not apply it, otherwise it breaks the specific configuration made for this package.
 You can manually reset the configuration with following command:
-`sudo su - duniter -c "duniter config --bma --ipv4 127.0.0.1 --port CHOSEN_PORT --remoteh YOUR_DOMAIN --remotep 443 --noupnp"`
+`sudo su - duniter -c "duniter --home \$HOME config --bma --ipv4 127.0.0.1 --port CHOSEN_PORT --remoteh YOUR_DOMAIN --remotep 443 --noupnp"`
 
 ## Cesium
 Cesium is a wallet webapp. You can install it with:

--- a/README_fr.md
+++ b/README_fr.md
@@ -24,12 +24,12 @@ Logiciel de cryptomonnaie pour faire fonctionner la monnaie libre Ğ1
 ## Avertissements / informations importantes
 
 ## Configurations
-- In order to compute blocks you will have to set your member credentials with `sudo su - duniter -c "duniter wizard key"` or from the webadmin.
+- In order to compute blocks you will have to set your member credentials with `sudo su - duniter -c "duniter --home \$HOME wizard key"` or from the webadmin.
 - BMA, the client API is accessible from `https://duniter.domain.tld/bma/` if enabled . The last `/` is necessary. It can be used in Cesium and Silkaj.
 - The web administration interface is accessible via `https://duniter.domain.tld/` and is only accessible to the administrator specified at the installation.
 - **Warning**: In case the Webui tells you your network configuration is wrong and proposes to correct it, do not apply it, otherwise it breaks the specific configuration made for this package.
 You can manually reset the configuration with following command:
-`sudo su - duniter -c "duniter config --bma --ipv4 127.0.0.1 --port CHOSEN_PORT --remoteh YOUR_DOMAIN --remotep 443 --noupnp"`
+`sudo su - duniter -c "duniter --home \$HOME config --bma --ipv4 127.0.0.1 --port CHOSEN_PORT --remoteh YOUR_DOMAIN --remotep 443 --noupnp"`
 
 ## Cesium
 Cesium is a wallet webapp. You can install it with:

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Logiciel de cryptomonnaie pour faire fonctionner la monnaie libre Ğ1
 
-**Version incluse :** 1.8.2~ynh1
+**Version incluse :** 1.8.2~ynh2
 
 
 

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -1,10 +1,10 @@
 ## Configurations
-- In order to compute blocks you will have to set your member credentials with `sudo su - duniter -c "duniter wizard key"` or from the webadmin.
+- In order to compute blocks you will have to set your member credentials with `sudo su - duniter -c "duniter --home \$HOME wizard key"` or from the webadmin.
 - BMA, the client API is accessible from `https://duniter.domain.tld/bma/` if enabled . The last `/` is necessary. It can be used in Cesium and Silkaj.
 - The web administration interface is accessible via `https://duniter.domain.tld/` and is only accessible to the administrator specified at the installation.
 - **Warning**: In case the Webui tells you your network configuration is wrong and proposes to correct it, do not apply it, otherwise it breaks the specific configuration made for this package.
 You can manually reset the configuration with following command:
-`sudo su - duniter -c "duniter config --bma --ipv4 127.0.0.1 --port CHOSEN_PORT --remoteh YOUR_DOMAIN --remotep 443 --noupnp"`
+`sudo su - duniter -c "duniter --home \$HOME config --bma --ipv4 127.0.0.1 --port CHOSEN_PORT --remoteh YOUR_DOMAIN --remotep 443 --noupnp"`
 
 ## Cesium
 Cesium is a wallet webapp. You can install it with:

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Crypto-currency software to operate Ğ1 libre currency",
         "fr": "Logiciel de cryptomonnaie pour faire fonctionner la monnaie libre Ğ1"
     },
-    "version": "1.8.2~ynh1",
+    "version": "1.8.2~ynh2",
     "url": "https://duniter.org",
     "license": "AGPL-3.0-or-later",
     "upstream": {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -11,8 +11,8 @@ pkg_dependencies="deb1 deb2 php$YNH_DEFAULT_PHP_VERSION-deb1 php$YNH_DEFAULT_PHP
 # PERSONAL HELPERS
 #=================================================
 CONFIGURE_DUNITER() {
-	ynh_exec_as duniter duniter config --bma --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
-	ynh_exec_as duniter duniter config --ws2p-host 127.0.0.1 --ws2p-port 20901 --ws2p-remote-host $domain --ws2p-remote-port 443 --ws2p-remote-path "/ws2p" --ws2p-noupnp
+	ynh_exec_as duniter duniter --home $datadir config --bma --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
+	ynh_exec_as duniter duniter --home $datadir config --ws2p-host 127.0.0.1 --ws2p-port 20901 --ws2p-remote-host $domain --ws2p-remote-port 443 --ws2p-remote-path "/ws2p" --ws2p-noupnp
 
 }
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -14,6 +14,8 @@ CONFIGURE_DUNITER() {
 	ynh_exec_as duniter duniter --home $datadir config --bma --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
 	ynh_exec_as duniter duniter --home $datadir config --ws2p-host 127.0.0.1 --ws2p-port 20901 --ws2p-remote-host $domain --ws2p-remote-port 443 --ws2p-remote-path "/ws2p" --ws2p-noupnp
 
+	# Add BMAS with path, remove auto-generated BMAS endpoint
+	ynh_exec_as duniter duniter --home $datadir config --addep "BMAS $domain 443 /bma" --remep "BMAS $domain 443"
 }
 
 #=================================================

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,6 +10,11 @@ pkg_dependencies="deb1 deb2 php$YNH_DEFAULT_PHP_VERSION-deb1 php$YNH_DEFAULT_PHP
 #=================================================
 # PERSONAL HELPERS
 #=================================================
+CONFIGURE_DUNITER() {
+	ynh_exec_as duniter duniter config --bma --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
+	ynh_exec_as duniter duniter config --ws2p-host 127.0.0.1 --ws2p-port 20901 --ws2p-remote-host $domain --ws2p-remote-port 443 --ws2p-remote-path "/ws2p" --ws2p-noupnp
+
+}
 
 #=================================================
 # EXPERIMENTAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -99,12 +99,11 @@ chmod -R o-rwx "$datadir"
 chown -R $app:www-data "$datadir"
 
 #=================================================
-# ADD A CONFIG FILE
+# CONFIGURE DUNITER
 #=================================================
-ynh_script_progression --message="Adding a configuration file…"
+ynh_script_progression --message="Configure Duniter…"
 
-ynh_exec_as duniter duniter config --bma --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
-ynh_exec_as duniter duniter config --ws2p-host 127.0.0.1 --ws2p-port 20901 --ws2p-remote-host $domain --ws2p-remote-port 443 --ws2p-remote-path "/ws2p" --ws2p-noupnp
+CONFIGURE_DUNITER
 
 #=================================================
 # SETUP SYSTEMD

--- a/scripts/restore
+++ b/scripts/restore
@@ -76,12 +76,11 @@ ynh_setup_source --dest_dir=$tempdir --source_id=$architecture
 ynh_exec_warn_less dpkg -i $tempdir/duniter-server-v1.8.*-linux-*.deb
 
 #=================================================
-# ADD A CONFIG FILE
+# CONFIGURE DUNITER
 #=================================================
-ynh_script_progression --message="Adding a configuration file…"
+ynh_script_progression --message="Configure Duniter…"
 
-ynh_exec_as duniter duniter --home $datadir config --bma --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
-ynh_exec_as duniter duniter --home $datadir config --ws2p-host 127.0.0.1 --ws2p-port 20901 --ws2p-remote-host $domain --ws2p-remote-port 443 --ws2p-remote-path "/ws2p" --ws2p-noupnp
+CONFIGURE_DUNITER
 
 #=================================================
 # RESTORE SYSTEMD

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -109,12 +109,11 @@ if [[ ! -d "${datadir}" ]]; then
 fi
 
 #=================================================
-# UPDATE A CONFIG FILE
+# UPDATE DUNITER CONFIG FILE
 #=================================================
-ynh_script_progression --message="Updating a configuration file…"
+ynh_script_progression --message="Configure Duniter…"
 
-ynh_exec_as duniter duniter config --bma --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
-ynh_exec_as duniter duniter config --ws2p-host 127.0.0.1 --ws2p-port 20901 --ws2p-remote-host $domain --ws2p-remote-port 443 --ws2p-remote-path "/ws2p" --ws2p-noupnp
+CONFIGURE_DUNITER
 
 #=================================================
 # SETUP SYSTEMD


### PR DESCRIPTION
- Move Duniter configuration in `_common.sh`
- Fix home directory to apply configuration
- Add BMA endpoint definition with `/bma` path