### PR TITLE
Bump ARM Duniter Deb pkg to v1.8.5, requires YnH v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Crypto-currency software to operate Ğ1 libre currency
 
-**Shipped version:** 1.8.5~ynh0
+**Shipped version:** 1.8.5~ynh1
 
 
 ## Screenshots

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Logiciel de cryptomonnaie pour faire fonctionner la monnaie libre Ğ1
 
-**Version incluse :** 1.8.5~ynh0
+**Version incluse :** 1.8.5~ynh1
 
 
 ## Captures d'écran

--- a/conf/armhf.src
+++ b/conf/armhf.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://git.duniter.org/nodes/typescript/duniter/uploads/727923b2f5eb6b0569b8e9362b24c234/duniter-server-v1.8.2-linux-armv7l.deb
-SOURCE_SUM=dbc01b88c726d7a70c6bfa549bae3b9d4c99c07cc23918ed8c2e68314ac6d669
+SOURCE_URL=https://git.duniter.org/nodes/typescript/duniter/uploads/8773273a64956cb02de555ec72e4d2bd/duniter-server-v1.8.5-linux-armv7l.deb
+SOURCE_SUM=498e3a7766e167887de2d71dd43ffa6c1add11f976bf00e2a44ccc3cec5d5da0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=duniter-server-v1.8.2-linux-armv7l.deb
+SOURCE_FILENAME=duniter-server-v1.8.5-linux-armv7l.deb
 SOURCE_EXTRACT=false

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Crypto-currency software to operate Ğ1 libre currency",
         "fr": "Logiciel de cryptomonnaie pour faire fonctionner la monnaie libre Ğ1"
     },
-    "version": "1.8.5~ynh0",
+    "version": "1.8.5~ynh1",
     "url": "https://duniter.org",
     "license": "AGPL-3.0-or-later",
     "upstream": {
@@ -20,7 +20,7 @@
         "url": "https://moul.re"
     },
     "requirements": {
-        "yunohost": ">= 4.3.0"
+        "yunohost": ">= 11.0.0"
     },
     "multi_instance": false,
     "services": [


### PR DESCRIPTION
Set YunoHost/Debian Bullseye v11 as requirement
since the ARM package was built on Bullseye and doesn't
support Buster