### PR TITLE
Re-add proper public APIs accesses

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -5,4 +5,7 @@
 - [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)
 - [Le o README en galego](README_gl.md)
+- [Baca README dalam bahasa bahasa Indonesia](README_id.md)
+- [Lees de README in het Nederlands](README_nl.md)
+- [Прочитать README на русский](README_ru.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Duniter for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/duniter.svg)](https://dash.yunohost.org/appci/app/duniter) ![Working status](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+[![Integration level](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![Working status](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
 
 [![Install Duniter with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
 
@@ -19,7 +19,7 @@ It shall NOT be edited by hand.
 Crypto-currency software to operate the Ğ1 libre currency.
 
 
-**Shipped version:** 1.8.7~ynh2
+**Shipped version:** 1.8.7~ynh3
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,7 @@ No se debe editar a mano.
 
 # Duniter para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/duniter.svg)](https://dash.yunohost.org/appci/app/duniter) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+[![Nivel de integración](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
 
 [![Instalar Duniter con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
 
@@ -19,7 +19,7 @@ No se debe editar a mano.
 Crypto-currency software to operate the Ğ1 libre currency.
 
 
-**Versión actual:** 1.8.7~ynh2
+**Versión actual:** 1.8.7~ynh3
 
 ## Capturas
 
@@ -34,7 +34,7 @@ Crypto-currency software to operate the Ğ1 libre currency.
 
 ## Información para desarrolladores
 
-Por favor enviar sus correcciones a la [`branch testing`](https://github.com/YunoHost-Apps/duniter_ynh/tree/testing
+Por favor enviar sus correcciones a la [rama `testing`](https://github.com/YunoHost-Apps/duniter_ynh/tree/testing).
 
 Para probar la rama `testing`, sigue asÍ:
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,7 @@ EZ editatu eskuz.
 
 # Duniter YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/duniter.svg)](https://dash.yunohost.org/appci/app/duniter) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+[![Integrazio maila](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
 
 [![Instalatu Duniter YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
 
@@ -19,7 +19,7 @@ EZ editatu eskuz.
 Crypto-currency software to operate the Ğ1 libre currency.
 
 
-**Paketatutako bertsioa:** 1.8.7~ynh2
+**Paketatutako bertsioa:** 1.8.7~ynh3
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,7 @@ Il NE doit PAS être modifié à la main.
 
 # Duniter pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/duniter.svg)](https://dash.yunohost.org/appci/app/duniter) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+[![Niveau d’intégration](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
 
 [![Installer Duniter avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
 
@@ -19,7 +19,7 @@ Il NE doit PAS être modifié à la main.
 Crypto-currency software to operate the Ğ1 libre currency.
 
 
-**Version incluse :** 1.8.7~ynh2
+**Version incluse :** 1.8.7~ynh3
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,7 @@ NON debe editarse manualmente.
 
 # Duniter para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/duniter.svg)](https://dash.yunohost.org/appci/app/duniter) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+[![Nivel de integración](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
 
 [![Instalar Duniter con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
 
@@ -19,7 +19,7 @@ NON debe editarse manualmente.
 Crypto-currency software to operate the Ğ1 libre currency.
 
 
-**Versión proporcionada:** 1.8.7~ynh2
+**Versión proporcionada:** 1.8.7~ynh3
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -1,0 +1,47 @@
+<!--
+N.B.: README ini dibuat secara otomatis oleh <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Ini TIDAK boleh diedit dengan tangan.
+-->
+
+# Duniter untuk YunoHost
+
+[![Tingkat integrasi](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![Status kerja](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Status pemeliharaan](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+
+[![Pasang Duniter dengan YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
+
+*[Baca README ini dengan bahasa yang lain.](./ALL_README.md)*
+
+> *Paket ini memperbolehkan Anda untuk memasang Duniter secara cepat dan mudah pada server YunoHost.*  
+> *Bila Anda tidak mempunyai YunoHost, silakan berkonsultasi dengan [panduan](https://yunohost.org/install) untuk mempelajari bagaimana untuk memasangnya.*
+
+## Ringkasan
+
+Crypto-currency software to operate the Ğ1 libre currency.
+
+
+**Versi terkirim:** 1.8.7~ynh3
+
+## Tangkapan Layar
+
+![Tangkapan Layar pada Duniter](./doc/screenshots/duniter_admin_g1.png)
+
+## Dokumentasi dan sumber daya
+
+- Website aplikasi resmi: <https://duniter.org>
+- Depot kode aplikasi hulu: <https://git.duniter.org/nodes/typescript/duniter>
+- Gudang YunoHost: <https://apps.yunohost.org/app/duniter>
+- Laporkan bug: <https://github.com/YunoHost-Apps/duniter_ynh/issues>
+
+## Info developer
+
+Silakan kirim pull request ke [`testing` branch](https://github.com/YunoHost-Apps/duniter_ynh/tree/testing).
+
+Untuk mencoba branch `testing`, silakan dilanjutkan seperti:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/duniter_ynh/tree/testing --debug
+atau
+sudo yunohost app upgrade duniter -u https://github.com/YunoHost-Apps/duniter_ynh/tree/testing --debug
+```
+
+**Info lebih lanjut mengenai pemaketan aplikasi:** <https://yunohost.org/packaging_apps>

--- a/README_nl.md
+++ b/README_nl.md
@@ -1,0 +1,47 @@
+<!--
+NB: Deze README is automatisch gegenereerd door <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Hij mag NIET handmatig aangepast worden.
+-->
+
+# Duniter voor Yunohost
+
+[![Integratieniveau](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![Mate van functioneren](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Onderhoudsstatus](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+
+[![Duniter met Yunohost installeren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
+
+*[Deze README in een andere taal lezen.](./ALL_README.md)*
+
+> *Met dit pakket kun je Duniter snel en eenvoudig op een YunoHost-server installeren.*  
+> *Als je nog geen YunoHost hebt, lees dan [de installatiehandleiding](https://yunohost.org/install), om te zien hoe je 'm installeert.*
+
+## Overzicht
+
+Crypto-currency software to operate the Ğ1 libre currency.
+
+
+**Geleverde versie:** 1.8.7~ynh3
+
+## Schermafdrukken
+
+![Schermafdrukken van Duniter](./doc/screenshots/duniter_admin_g1.png)
+
+## Documentatie en bronnen
+
+- Officiele website van de app: <https://duniter.org>
+- Upstream app codedepot: <https://git.duniter.org/nodes/typescript/duniter>
+- YunoHost-store: <https://apps.yunohost.org/app/duniter>
+- Meld een bug: <https://github.com/YunoHost-Apps/duniter_ynh/issues>
+
+## Ontwikkelaarsinformatie
+
+Stuur je pull request alsjeblieft naar de [`testing`-branch](https://github.com/YunoHost-Apps/duniter_ynh/tree/testing).
+
+Om de `testing`-branch uit te proberen, ga als volgt te werk:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/duniter_ynh/tree/testing --debug
+of
+sudo yunohost app upgrade duniter -u https://github.com/YunoHost-Apps/duniter_ynh/tree/testing --debug
+```
+
+**Verdere informatie over app-packaging:** <https://yunohost.org/packaging_apps>

--- a/README_ru.md
+++ b/README_ru.md
@@ -1,0 +1,47 @@
+<!--
+Важно: этот README был автоматически сгенерирован <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Он НЕ ДОЛЖЕН редактироваться вручную.
+-->
+
+# Duniter для YunoHost
+
+[![Уровень интеграции](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![Состояние работы](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![Состояние сопровождения](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+
+[![Установите Duniter с YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
+
+*[Прочтите этот README на других языках.](./ALL_README.md)*
+
+> *Этот пакет позволяет Вам установить Duniter быстро и просто на YunoHost-сервер.*  
+> *Если у Вас нет YunoHost, пожалуйста, посмотрите [инструкцию](https://yunohost.org/install), чтобы узнать, как установить его.*
+
+## Обзор
+
+Crypto-currency software to operate the Ğ1 libre currency.
+
+
+**Поставляемая версия:** 1.8.7~ynh3
+
+## Снимки экрана
+
+![Снимок экрана Duniter](./doc/screenshots/duniter_admin_g1.png)
+
+## Документация и ресурсы
+
+- Официальный веб-сайт приложения: <https://duniter.org>
+- Репозиторий кода главной ветки приложения: <https://git.duniter.org/nodes/typescript/duniter>
+- Магазин YunoHost: <https://apps.yunohost.org/app/duniter>
+- Сообщите об ошибке: <https://github.com/YunoHost-Apps/duniter_ynh/issues>
+
+## Информация для разработчиков
+
+Пришлите Ваш запрос на слияние в [ветку `testing`](https://github.com/YunoHost-Apps/duniter_ynh/tree/testing).
+
+Чтобы попробовать ветку `testing`, пожалуйста, сделайте что-то вроде этого:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/duniter_ynh/tree/testing --debug
+или
+sudo yunohost app upgrade duniter -u https://github.com/YunoHost-Apps/duniter_ynh/tree/testing --debug
+```
+
+**Больше информации о пакетировании приложений:** <https://yunohost.org/packaging_apps>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,7 @@
 
 # YunoHost 上的 Duniter
 
-[![集成程度](https://dash.yunohost.org/integration/duniter.svg)](https://dash.yunohost.org/appci/app/duniter) ![工作状态](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
+[![集成程度](https://dash.yunohost.org/integration/duniter.svg)](https://ci-apps.yunohost.org/ci/apps/duniter/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/duniter.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/duniter.maintain.svg)
 
 [![使用 YunoHost 安装 Duniter](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=duniter)
 
@@ -19,7 +19,7 @@
 Crypto-currency software to operate the Ğ1 libre currency.
 
 
-**分发版本：** 1.8.7~ynh2
+**分发版本：** 1.8.7~ynh3
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Duniter"
 description.en = "Crypto-currency software to operate Ğ1 libre currency"
 description.fr = "Logiciel de cryptomonnaie pour faire fonctionner la monnaie libre Ğ1"
 
-version = "1.8.7~ynh2"
+version = "1.8.7~ynh3"
 
 maintainers = ["Moul"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -35,7 +35,7 @@ ram.runtime = "200M"
 
     [install.init_main_permission]
     type = "group"
-    default = "visitors"
+    default = "admins"
 
 [resources]
     [resources.sources.main]
@@ -56,6 +56,11 @@ ram.runtime = "200M"
     main.url = "/"
     admin.allowed = "admins"
     admin.additional_urls = ["/webmin"]
+
+    apis.url = "/bma"
+    apis.show_tile = true
+    apis.allowed = "visitors"
+    apis.additional_urls = ["/ws2p"]
 
     [resources.ports]
     web_admin.default = 8000


### PR DESCRIPTION
BMA (clients), WS2P (server) APIs were simply not longer publicly accessible

Porting to v2 packaging did not took care of maintaining this important feature working

Default permission to "/" webadmin is "admins", if the users choses the default value, no issue the webadmin is completely not accessible

In case `visitors` is selected, `/` is accessible to visitors, but its API path `/webmin` is not. Which is hopefully safe.
Just assets are accessible, but no informaton nor command can be received or sent about data of the instance

It has to be this way, since the CI wants to be able to choose `visitors` for its tests, probably for beeing able to check that the app is accessible via its path.

https://github.com/YunoHost-Apps/duniter_ynh/pull/113/commits/ec6f83282789f1bb240cf59547dc970c342662e6#diff-6233345de4867c7ccf72bac1fc1067988d2a4c8e1ab9a746956eafccf88cfed2L142-L147 wasn’t preserved

- Bump to third revision: `1.8.7~ynh3`